### PR TITLE
売却済みの商品の編集ページに遷移できないように

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -52,7 +52,7 @@ class ItemsController < ApplicationController
 
   def move_to_index
     item = Item.find(params[:id])
-    redirect_to action: :index unless item.user.id == current_user.id
+    redirect_to action: :index unless (item.user.id == current_user.id)  || item.order == nil
   end
 
   def set_item


### PR DESCRIPTION
# what 
売却済みの商品の編集ページに遷移できないようにする

# why
商品購入機能の漏れを修正するため


本番環境で挙動をチェックしたところ１点実装漏れを発見したのでレビュー依頼いたします。ご確認いただければと思います。

出品者・出品者以外にかかわらず、ログイン状態のユーザーが、URLを直接入力して売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移すること
https://gyazo.com/827731eef0da2a5302f3ca21b78eeae2
