### PR TITLE
売却済み編集ページに遷移できないようにする２

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -52,7 +52,7 @@ class ItemsController < ApplicationController
 
   def move_to_index
     item = Item.find(params[:id])
-    redirect_to action: :index unless (item.user.id == current_user.id)  || item.order == nil
+    redirect_to action: :index if (item.user.id != current_user.id) || item.order
   end
 
   def set_item


### PR DESCRIPTION
# what
売却済み編集ページに遷移できないように のコードに誤りがあったので修正いたします

# why
購入機能実装漏れ修正のため

https://gyazo.com/1ca64ca9ab5e136bbbc60ac879f3247f

よろしくお願い致します
